### PR TITLE
update Oxide README for RFD 211 changes

### DIFF
--- a/README.oxide.md
+++ b/README.oxide.md
@@ -6,18 +6,13 @@ writing, the upstream pq-sys repo does not appear to be actively maintained.  If
 the fixes in this fork are integrated upstream and an updated version of pq-sys
 is released, we should delete this fork.
 
-This fork is used in [Omicron](https://github.com/oxidecomputer/omicron).
+The branches in this fork are managed as described in [RFD
+211](https://rfd.shared.oxide.computer/rfd/0211).  There is currently one
+consumer, [Omicron](https://github.com/oxidecomputer/omicron), which uses the
+"oxide/omicron" branch.
 
-The branches in this fork that correspond with upstream branches (like "master")
-should be kept in sync with upstream.  We don't want to put local changes on
-these branches because that will make it harder to keep our own changes separate
-and still sync up with upstream.
+Other vestigial branches here include:
 
-This fork contains branches:
-
-- "oxide": the root of our local changes.  This branch contains this README and
-  some GitHub actions to aid testing.
-- "omicron": the branch currently used by omicron.
 - "issue-36": a branch used for upstream PR#37.  This PR was abandoned.  The
   branch contains only the relevant change, not the other local changes here
   (like this README).


### PR DESCRIPTION
This repo predated [RFD 211 Maintaining forks of third-party repositories](https://rfd.shared.oxide.computer/rfd/0211).  This change (and some other changes that I'll describe below) update the repo to align with RFD 211.